### PR TITLE
Allow more granular access during maintenance mode

### DIFF
--- a/maintenancemode/middleware.py
+++ b/maintenancemode/middleware.py
@@ -19,6 +19,9 @@ class MaintenanceModeMiddleware(object):
 
     def process_request(self, request):
         # Allow access if middleware is not activated
+        allow_staff = getattr(settings, 'MAINTENANCE_ALLOW_STAFF', True)
+        allow_superuser = getattr(settings, 'MAINTENANCE_ALLOW_SUPERUSER', True)
+
         if not (settings.MAINTENANCE_MODE or maintenance.status()):
             return None
 
@@ -36,8 +39,12 @@ class MaintenanceModeMiddleware(object):
 
         # Allow access if the user doing the request is logged in and a
         # staff member.
-        if hasattr(request, 'user') and request.user.is_staff:
-            return None
+        if hasattr(request, 'user'):
+            if request.user.is_staff and allow_staff:
+                return None
+
+            if request.user.is_superuser and allow_superuser:
+                return None
 
         # Check if a path is explicitly excluded from maintenance mode
         for url in IGNORE_URLS:

--- a/maintenancemode/tests.py
+++ b/maintenancemode/tests.py
@@ -96,6 +96,39 @@ class MaintenanceModeMiddlewareTestCase(TestCase):
             response = self.client.get('/')
         self.assertContains(response, text='Rendered response page', count=1, status_code=200)
 
+    def test_middleware_with_staff_user_denied(self):
+        # A logged in user that _is_ a staff user should be able to
+        # use the site normally
+        User.objects.filter(pk=self.user.pk).update(is_staff=True)
+
+        self.client.login(username='maintenance', password='password')
+
+        with self.settings(MAINTENANCE_MODE=True, MAINTENANCE_ALLOW_STAFF=False, TEMPLATE_DIRS=TEMPLATE_DIRS, TEMPLATES=TEMPLATES):
+            response = self.client.get('/')
+        self.assertContains(response, text='Temporary unavailable', count=1, status_code=503)
+
+    def test_middleware_with_superuser_user_denied(self):
+        # A logged in user that _is_ a staff user should be able to
+        # use the site normally
+        User.objects.filter(pk=self.user.pk).update(is_superuser=True)
+
+        self.client.login(username='maintenance', password='password')
+
+        with self.settings(MAINTENANCE_MODE=True, MAINTENANCE_ALLOW_SUPERUSER=False, TEMPLATE_DIRS=TEMPLATE_DIRS, TEMPLATES=TEMPLATES):
+            response = self.client.get('/')
+        self.assertContains(response, text='Temporary unavailable', count=1, status_code=503)
+
+    def test_middleware_with_superuser_user_allowed(self):
+        # A logged in user that _is_ a staff user should be able to
+        # use the site normally
+        User.objects.filter(pk=self.user.pk).update(is_superuser=True)
+
+        self.client.login(username='maintenance', password='password')
+
+        with self.settings(MAINTENANCE_MODE=True, TEMPLATE_DIRS=TEMPLATE_DIRS, TEMPLATES=TEMPLATES):
+            response = self.client.get('/')
+        self.assertContains(response, text='Rendered response page', count=1, status_code=200)
+
     def test_middleware_with_internal_ips(self):
         # A user that visits the site from an IP in ``INTERNAL_IPS``
         # should be able to use the site normally

--- a/maintenancemode/tests.py
+++ b/maintenancemode/tests.py
@@ -125,7 +125,7 @@ class MaintenanceModeMiddlewareTestCase(TestCase):
 
         self.client.login(username='maintenance', password='password')
 
-        with self.settings(MAINTENANCE_MODE=True, TEMPLATE_DIRS=TEMPLATE_DIRS, TEMPLATES=TEMPLATES):
+        with self.settings(MAINTENANCE_MODE=True, MAINTENANCE_ALLOW_STAFF=False, TEMPLATE_DIRS=TEMPLATE_DIRS, TEMPLATES=TEMPLATES):
             response = self.client.get('/')
         self.assertContains(response, text='Rendered response page', count=1, status_code=200)
 


### PR DESCRIPTION
I have a system where I have Staff users and during maintenance windows I need them to not have access. However a superuser who better understands what's happening during these maintenance windows I do want to have access.

ref #19 

Right now, in order to address this, I have to put the middleware before the AuthenticationMiddleware... sad music indeed =,(
