### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,59 @@ matrix:
       python: 3.8
     - env: TOXENV=py38-dj3
       python: 3.8
+# Adding jobs for ppc64le
+    - env: TOXENV=py34-dj111
+      python: 3.4
+      arch: ppc64le
+    - env: TOXENV=py34-dj2
+      python: 3.4
+      arch: ppc64le
+    - env: TOXENV=py35-dj111
+      python: 3.5
+      arch: ppc64le
+    - env: TOXENV=py35-dj2
+      python: 3.5
+      arch: ppc64le
+    - env: TOXENV=py35-dj21
+      python: 3.5
+      arch: ppc64le
+    - env: TOXENV=py35-dj22
+      python: 3.5
+      arch: ppc64le
+    - env: TOXENV=py36-dj111
+      python: 3.6
+      arch: ppc64le
+    - env: TOXENV=py36-dj2
+      python: 3.6
+      arch: ppc64le
+    - env: TOXENV=py36-dj21
+      python: 3.6
+      arch: ppc64le
+    - env: TOXENV=py36-dj22
+      python: 3.6
+      arch: ppc64le
+    - env: TOXENV=py36-dj3
+      python: 3.6
+      arch: ppc64le
+    - env: TOXENV=py37-dj2
+      python: 3.7
+      arch: ppc64le
+    - env: TOXENV=py37-dj21
+      python: 3.7
+      arch: ppc64le
+    - env: TOXENV=py37-dj22
+      python: 3.7
+      arch: ppc64le
+    - env: TOXENV=py37-dj3
+      python: 3.7
+      arch: ppc64le
+    - env: TOXENV=py38-dj22
+      python: 3.8
+      arch: ppc64le
+    - env: TOXENV=py38-dj3
+      python: 3.8
+      arch: ppc64le
+     
 
 install:
   - pip install tox 


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-maintenancemode/builds/188988956

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj