### PR TITLE
Fix compatibility issues and test for Django 3

### DIFF
--- a/maintenancemode/tests/settings.py
+++ b/maintenancemode/tests/settings.py
@@ -54,3 +54,6 @@ SITE_ID = 1
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+
+
+MAINTENANCE_IGNORE_URLS = (re.compile(r"^/ignored.*"),)

--- a/maintenancemode/tests/test_middleware.py
+++ b/maintenancemode/tests/test_middleware.py
@@ -127,8 +127,11 @@ class MaintenanceModeMiddlewareTestCase(TestCase):
         # A path is ignored when applying the maintanance mode and
         # should be reachable normally
         with self.settings(MAINTENANCE_MODE=True):
-            with self.settings(IGNORE_URLS=(re.compile(r"^/ignored.*"),)):
-                response = self.client.get("/ignored/")
+            # Note that we cannot override the settings here, since they are
+            # ONLY used when the middleware starts up.
+            # For this reason, MAINTENANCE_IGNORE_URLS is set in the base
+            # settings file.
+            response = self.client.get("/ignored/")
         self.assertContains(response, text="Rendered response page", count=1, status_code=200)
 
     def test_management_command(self):

--- a/maintenancemode/tests/urls.py
+++ b/maintenancemode/tests/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from django.http import HttpResponse
 
 urlpatterns = [
-    url("^$", lambda r: HttpResponse("Rendered response page"), name="test"),
-    url("^ignored/$", lambda r: HttpResponse("Rendered response page"), name="test"),
+    re_path("^$", lambda r: HttpResponse("Rendered response page"), name="test"),
+    re_path("^ignored/$", lambda r: HttpResponse("Rendered response page"), name="test"),
 ]


### PR DESCRIPTION
The test setup within 0.11.6 isn't working with Django 3 currently and is failing with this error:

```
$ PYTHONPATH=. python3.9 -m pytest
============================= test session starts =======================================
platform linux -- Python 3.9.7, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
Django settings: maintenancemode.tests.settings (from ini file)
rootdir: /home/carsten/gitprojects/pkg-python/django-maintenancemode, configfile: setup.cfg
plugins: cov-2.12.1, dependency-0.5.1, django-3.5.1
collected 13 items                                                                                                                                                                   

maintenancemode/tests/test_middleware.py ....F.FF.....                                                                                                                         [100%]

=============================  FAILURES =================================================
_______________ MaintenanceModeMiddlewareTestCase.test_ignored_path _____________________

self = <maintenancemode.tests.test_middleware.MaintenanceModeMiddlewareTestCase testMethod=test_ignored_path>

    def test_ignored_path(self):
        # A path is ignored when applying the maintanance mode and
        # should be reachable normally
        with self.settings(MAINTENANCE_MODE=True):
            with self.settings(IGNORE_URLS=(re.compile(r"^/ignored.*"),)):
                response = self.client.get("/ignored/")
      self.assertContains(response, text="Rendered response page", count=1, status_code=200)

maintenancemode/tests/test_middleware.py:132: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3/dist-packages/django/test/testcases.py:462: in assertContains
    text_repr, real_count, msg_prefix = self._assert_contains(
/usr/lib/python3/dist-packages/django/test/testcases.py:432: in _assert_contains
    self.assertEqual(
E   AssertionError: 503 != 200 : Couldn't retrieve content: Response code was 503 (expected 200)
--------------------------------- Captured log call -------------------------------------
ERROR    django.request:log.py:224 Service Unavailable: /ignored/
```

The following MR is fixing this issues.