### PR TITLE
Fix code to support Django 4 and up, edge case for code older than 3.2

### DIFF
--- a/maintenancemode/middleware.py
+++ b/maintenancemode/middleware.py
@@ -51,19 +51,19 @@ class MaintenanceModeMiddleware(MiddlewareMixin):
                 return None
         # Otherwise show the user the 503 page
 
-        if DJANGO_VERSION_MAJOR >= 3 and DJANGO_VERSION_MINOR >= 2:
-            # Checks if DJANGO version is great than 3.2.0 for breaking change
-            resolver = resolvers.get_resolver(None)
-            resolve = resolver.resolve_error_handler
-            callback = resolve('503')
-
-            return callback(request)
-        else:
+        if (DJANGO_VERSION_MAJOR == 3 and DJANGO_VERSION_MINOR <= 2) or DJANGO_VERSION_MAJOR < 3:
+            # Checks if DJANGO version is less than 3.2.0 for breaking change
             resolver = get_resolver()
 
             callback, param_dict = resolver.resolve_error_handler("503")
 
             return callback(request, **param_dict)
 
+        else:
+            # Default behaviour for django 3.2 and higher
+            resolver = resolvers.get_resolver(None)
+            resolve = resolver.resolve_error_handler
+            callback = resolve('503')
 
+            return callback(request)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-maintenancemode
-version = 0.11.7
+version = 0.11.8
 description = django-maintenancemode allows you to temporary shutdown your site for maintenance work
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
Past django 3.2 there was a breaking change in the middleware I fixed before, but forgot to account for newer version in logic. This should be the required fix for that